### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/farmlib/expbar.py
+++ b/farmlib/expbar.py
@@ -29,8 +29,7 @@ class ExpBar(Label):
         self.oldexp = self.player.exp
         # calculate progress and set text
         progress = int(exp / nextlvlexp * 100)
-        self.settext("Level: " + str(level) + " Exp: %s/%s (%s %%)" %
-                     (int(exp), int(nextlvlexp), progress), repaint=False)
+        self.settext("Level: " + str(level) + " Exp: {0!s}/{1!s} ({2!s} %)".format(int(exp), int(nextlvlexp), progress), repaint=False)
 
     def update(self):
         """update

--- a/farmlib/farm.py
+++ b/farmlib/farm.py
@@ -419,7 +419,7 @@ class Seed(FarmObject):
         if rem_secound < 10:
             rem_secound = "0" + str(rem_secound)
 
-        self.remainstring = "%sh %sm %ss" % (rem_hour, rem_minute, rem_secound)
+        self.remainstring = "{0!s}h {1!s}m {2!s}s".format(rem_hour, rem_minute, rem_secound)
 
         if self.growing:
 

--- a/farmlib/gamewindow.py
+++ b/farmlib/gamewindow.py
@@ -149,7 +149,7 @@ class GameWindow(Window):
         """
         player = self.gamemanager.getplayer()
         # Render current money
-        text = "Money: $%s " % player.money
+        text = "Money: ${0!s} ".format(player.money)
         self.moneylabel.settext(text)
 
     def recreate_inventory(self):

--- a/farmlib/marketwindow.py
+++ b/farmlib/marketwindow.py
@@ -69,14 +69,14 @@ class MarketWindow(Container):
         self.addwidget(closebutton)
 
         # refill watercan
-        waterbuybutton = Button("Refill water ($%s)" % WATERREFILLCOST,
+        waterbuybutton = Button("Refill water (${0!s})".format(WATERREFILLCOST),
                                 (10, 30), color=(128, 128, 255))
         waterbuybutton.connect("clicked", self.on_water_buy)
         self.addwidget(waterbuybutton)
 
         # Buy farm
         farmcost = self.gamemanager.getnextfarmcost()
-        self.buyfarm = Button("Buy new farm ($%s)" % farmcost,
+        self.buyfarm = Button("Buy new farm (${0!s})".format(farmcost),
                               (150, 30), color=(255, 0, 0))
         self.buyfarm.connect("clicked", self.on_farm_buy)
         self.addwidget(self.buyfarm)
@@ -165,7 +165,7 @@ class MarketWindow(Container):
         self.sellvalue.settext("")
         self.costvalue.settext("")
         farmcost = self.gamemanager.getnextfarmcost()
-        self.buyfarm.settext("Buy new farm ($%s)" % farmcost)
+        self.buyfarm.settext("Buy new farm (${0!s})".format(farmcost))
 
     def get_item_cost(self, itemid):
         """get item cost
@@ -194,9 +194,8 @@ class MarketWindow(Container):
         have = 0
         if self.player.item_in_inventory(itemid):
             have = self.player.itemscounter[str(itemid)]
-        self.buybutton.settext("BUY x%s (you have %s)" %
-                               (str(self.count), have))
-        self.sellbutton.settext("SELL x%s " % str(self.count))
+        self.buybutton.settext("BUY x{0!s} (you have {1!s})".format(str(self.count), have))
+        self.sellbutton.settext("SELL x{0!s} ".format(str(self.count)))
 
     def on_item_select(self, widget, itemid):
         """selected item

--- a/farmlib/pluginsystem.py
+++ b/farmlib/pluginsystem.py
@@ -44,7 +44,7 @@ class Event(object):
         self.priority = PRIORITY_NORMAL
 
     def __str__(self):
-        return "Event:%s Priority:%i Args:%s" % (
+        return "Event:{0!s} Priority:{1:d} Args:{2!s}".format(
             str(self.name), self.priority, str(self.args)
             )
 
@@ -91,11 +91,11 @@ class Listener(object):
         :param event:
         :return:
         """
-        handler = getattr(self, "handler_%s" % event.name, None)
+        handler = getattr(self, "handler_{0!s}".format(event.name), None)
         if handler:
             handler(**event.args)
         else:
-            print("Handler for event %s not found" % event.name)
+            print("Handler for event {0!s} not found".format(event.name))
 
 
 # PLUGIN
@@ -143,7 +143,7 @@ class PluginSystem(object):
         :return:
         """
         filehandler = logging.FileHandler(
-            filename='%s.log' % str(loggername))
+            filename='{0!s}.log'.format(str(loggername)))
         formatter = logging.Formatter(
             '%(asctime)-6s %(levelname)s - %(message)s')
         filehandler.setFormatter(formatter)
@@ -180,7 +180,7 @@ class PluginSystem(object):
             self.emit_event("pluginload", pluginname=plugin.name)
             return plugin
         except AttributeError:
-            msg = "Can't install plugin from %s." % str(pluginObject)
+            msg = "Can't install plugin from {0!s}.".format(str(pluginObject))
             if self.debug:
                 print(msg)
 
@@ -225,7 +225,7 @@ class PluginSystem(object):
         try:
             return self.globalhooks[hookname]
         except KeyError:
-            msg = "Cannot get Global Hook %s" % hookname
+            msg = "Cannot get Global Hook {0!s}".format(hookname)
             if self.debug:
                 print(msg)
 

--- a/farmlib/renderfunctions.py
+++ b/farmlib/renderfunctions.py
@@ -115,7 +115,7 @@ def render_seed_notify(surface, font, posx, posy, farmobject, farmtile,
         img.blit(text, (halfx - text.get_size()[0] / 2, 45))
 
         # Quentity
-        text = "Quantity: %s (%s)" % (str(farmobject.growquantity),
+        text = "Quantity: {0!s} ({1!s})".format(str(farmobject.growquantity),
                                       str(farmobject.harvestcount))
         text = font.render(text, 0, (255, 255, 150), (255, 0, 255))
         text.set_colorkey((255, 0, 255))


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:MarkusHackspacher:PythonFarmGame?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:MarkusHackspacher:PythonFarmGame?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
